### PR TITLE
import revtok for line 205 of metrics.py

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -9,9 +9,9 @@ import collections
 from multiprocessing import Pool, cpu_count
 from contextlib import closing
 
+import revtok
 from pyrouge import Rouge155
 from sacrebleu import corpus_bleu
-
 
 
 def to_lf(s, table):


### PR DESCRIPTION
Also, typo in function name: __corpus_gleu()__ --> __corpus_bleu()__ to match the import on line 14.

flake8 testing of https://github.com/salesforce/decaNLP on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./metrics.py:205:17: F821 undefined name 'revtok'
    tokenizer = revtok.tokenize
                ^
./metrics.py:210:12: F821 undefined name 'corpus_gleu'
    return corpus_gleu(targets, outputs) * 100
           ^
2     F821 undefined name 'revtok'
2
```