### PR TITLE
small fix for PyTorch 0.4 arange

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -45,7 +45,7 @@ class LSTMDecoder(nn.Module):
 
 def positional_encodings_like(x, t=None):
     if t is None:
-        positions = torch.arange(0, x.size(1))
+        positions = torch.arange(0., x.size(1))
         if x.is_cuda:
             positions = positions.cuda(x.get_device())
     else:


### PR DESCRIPTION
PyTorch 0.4's arange emits a tensor of dtype long if called with only integer bounds and without dtype.
With this lazy fix, I can run
```
python3 ./train.py --train_tasks squad --train_iterations 10  --gpus 0
```
without error.

I do get a number of deprecation warnings that I could submit patches for, but that would not be compatible with PyTorch 0.3.1, so you likely don't want those?