### PR TITLE
fix mkdir error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd dockerfiles && docker build -t decanlp . && cd -
 
 You will also need to make a `.data` directory and move the examples for the Winograd Schemas into it:
 ```bash
-mkdir .data/schema
+mkdir -p .data/schema
 mv local_data/schema.txt .data/schema/
 ```
 


### PR DESCRIPTION
mkdir: cannot create directory ‘.data/schema’: No such file or directory