### PR TITLE
Fix numerical field generation.

### DIFF
--- a/text/torchtext/data/example.py
+++ b/text/torchtext/data/example.py
@@ -57,9 +57,12 @@ class Example(object):
         ex = cls()
         for (name, field), val in zip(fields, data):
             if field is not None:
-                if isinstance(val, six.string_types):
-                    val = val.rstrip('\n')
-                setattr(ex, name, [sys.intern(x) for x in field.preprocess(val)])
+                if field.numerical:
+                    setattr(ex, name, val)
+                else:
+                    if isinstance(val, six.string_types):
+                        val = val.rstrip('\n')
+                    setattr(ex, name, [sys.intern(x) for x in field.preprocess(val)])
         return ex
 
     @classmethod


### PR DESCRIPTION
Numerical fields don't get tokenized. Now we can safely process the `wikisql_id` numerical Field.
Bug elusive to notice, because the examples are cached to disk.
Fixes https://github.com/salesforce/decaNLP/issues/27